### PR TITLE
Fixes banner messages for singular items

### DIFF
--- a/Sources/Components/Flat Feed/FlatFeedViewController.swift
+++ b/Sources/Components/Flat Feed/FlatFeedViewController.swift
@@ -157,11 +157,11 @@ extension FlatFeedViewController {
     
     /// Return a title of new activies for the banner view on updates.
     open func subscriptionNewItemsTitle(with count: Int) -> String {
-        return "You have \(count) new activit\(count == 1 "y" : "ies")"
+        return "You have \(count) new activit\(count == 1 ? "y" : "ies")"
     }
     
     /// Return a title of removed activities for the banner view on updates.
     open func subscriptionDeletedItemsTitle(with count: Int) -> String {
-        return "You have \(count) deleted activit\(count == 1 "y" : "ies")"
+        return "You have \(count) deleted activit\(count == 1 ? "y" : "ies")"
     }
 }

--- a/Sources/Components/Flat Feed/FlatFeedViewController.swift
+++ b/Sources/Components/Flat Feed/FlatFeedViewController.swift
@@ -157,11 +157,11 @@ extension FlatFeedViewController {
     
     /// Return a title of new activies for the banner view on updates.
     open func subscriptionNewItemsTitle(with count: Int) -> String {
-        return "You have \(count) new activities"
+        return "You have \(count) new activit\(count == 1 "y" : "ies")"
     }
     
     /// Return a title of removed activities for the banner view on updates.
     open func subscriptionDeletedItemsTitle(with count: Int) -> String {
-        return "You have \(count) deleted activities"
+        return "You have \(count) deleted activit\(count == 1 "y" : "ies")"
     }
 }


### PR DESCRIPTION
Instead of "You have 1 new activities" it should read "You have 1 new activity"