### PR TITLE
Fix comments being duplicated on refresh

### DIFF
--- a/Sources/Components/Flat Feed/DetailViewController.swift
+++ b/Sources/Components/Flat Feed/DetailViewController.swift
@@ -82,7 +82,7 @@ open class DetailViewController<T: ActivityProtocol>: BaseFlatFeedViewController
         updateSectionsIndex()
         
         if sections.contains(.comments) {
-            reactionPaginator?.load(.limit(100), completion: commentsLoaded)
+            reactionPaginator?.load(completion: commentsLoaded)
             
             if canAddComment {
                 if let user = User.current {
@@ -180,7 +180,7 @@ open class DetailViewController<T: ActivityProtocol>: BaseFlatFeedViewController
             
             refreshControl.addValueChangedAction { [weak self] _ in
                 if let self = self, let reactionPaginator = self.reactionPaginator {
-                    reactionPaginator.load(.limit(100), completion: self.commentsLoaded)
+                    reactionPaginator.load(completion: self.commentsLoaded)
                 }
             }
         }

--- a/Sources/Components/Flat Feed/DetailViewController.swift
+++ b/Sources/Components/Flat Feed/DetailViewController.swift
@@ -82,7 +82,7 @@ open class DetailViewController<T: ActivityProtocol>: BaseFlatFeedViewController
         updateSectionsIndex()
         
         if sections.contains(.comments) {
-            resetComments()
+            reloadComments()
             
             if canAddComment {
                 if let user = User.current {
@@ -140,7 +140,7 @@ open class DetailViewController<T: ActivityProtocol>: BaseFlatFeedViewController
         self.sectionsData = sectionsData
     }
     
-    private func resetComments() {
+    private func reloadComments() {
         reactionPaginator?.reset()
         reactionPaginator?.load(.limit(100), completion: commentsLoaded)
     }
@@ -184,7 +184,7 @@ open class DetailViewController<T: ActivityProtocol>: BaseFlatFeedViewController
             tableView.refreshControl = refreshControl
             
             refreshControl.addValueChangedAction { [weak self] _ in
-                self?.resetComments()
+                self?.reloadComments()
             }
         }
     }
@@ -375,7 +375,7 @@ open class DetailViewController<T: ActivityProtocol>: BaseFlatFeedViewController
                     if let error = $0.error {
                         self?.showErrorAlert(error)
                     } else if let self = self {
-                        self.resetComments()
+                        self.reloadComments()
                     }
                 }
             } else {
@@ -490,7 +490,7 @@ open class DetailViewController<T: ActivityProtocol>: BaseFlatFeedViewController
                                                             if let error = $0.error {
                                                                 self.showErrorAlert(error)
                                                             } else {
-                                                                self.resetComments()
+                                                                self.reloadComments()
                                                             }
                                                         }
         }

--- a/Sources/Components/Flat Feed/DetailViewController.swift
+++ b/Sources/Components/Flat Feed/DetailViewController.swift
@@ -82,7 +82,8 @@ open class DetailViewController<T: ActivityProtocol>: BaseFlatFeedViewController
         updateSectionsIndex()
         
         if sections.contains(.comments) {
-            reactionPaginator?.load(completion: commentsLoaded)
+            reactionPaginator?.reset()
+            reactionPaginator?.load(.limit(100), completion: commentsLoaded)
             
             if canAddComment {
                 if let user = User.current {
@@ -180,7 +181,8 @@ open class DetailViewController<T: ActivityProtocol>: BaseFlatFeedViewController
             
             refreshControl.addValueChangedAction { [weak self] _ in
                 if let self = self, let reactionPaginator = self.reactionPaginator {
-                    reactionPaginator.load(completion: self.commentsLoaded)
+                    reactionPaginator.reset()
+                    reactionPaginator.load(.limit(100), completion: self.commentsLoaded)
                 }
             }
         }

--- a/Sources/Components/Flat Feed/DetailViewController.swift
+++ b/Sources/Components/Flat Feed/DetailViewController.swift
@@ -82,8 +82,7 @@ open class DetailViewController<T: ActivityProtocol>: BaseFlatFeedViewController
         updateSectionsIndex()
         
         if sections.contains(.comments) {
-            reactionPaginator?.reset()
-            reactionPaginator?.load(.limit(100), completion: commentsLoaded)
+            resetComments()
             
             if canAddComment {
                 if let user = User.current {
@@ -141,6 +140,11 @@ open class DetailViewController<T: ActivityProtocol>: BaseFlatFeedViewController
         self.sectionsData = sectionsData
     }
     
+    private func resetComments() {
+        reactionPaginator?.reset()
+        reactionPaginator?.load(.limit(100), completion: commentsLoaded)
+    }
+    
     /// Return a title of the section by the section type.
     open func sectionTitle(for type: DetailViewControllerSectionTypes) -> String? {
         if type == .likes {
@@ -180,10 +184,7 @@ open class DetailViewController<T: ActivityProtocol>: BaseFlatFeedViewController
             tableView.refreshControl = refreshControl
             
             refreshControl.addValueChangedAction { [weak self] _ in
-                if let self = self, let reactionPaginator = self.reactionPaginator {
-                    reactionPaginator.reset()
-                    reactionPaginator.load(.limit(100), completion: self.commentsLoaded)
-                }
+                self?.resetComments()
             }
         }
     }
@@ -373,8 +374,8 @@ open class DetailViewController<T: ActivityProtocol>: BaseFlatFeedViewController
                 activityPresenter.reactionPresenter.remove(reaction: comment, activity: activityPresenter.activity) { [weak self] in
                     if let error = $0.error {
                         self?.showErrorAlert(error)
-                    } else if let self = self{
-                        self.reactionPaginator?.load(.limit(100), completion: self.commentsLoaded)
+                    } else if let self = self {
+                        self.resetComments()
                     }
                 }
             } else {
@@ -489,7 +490,7 @@ open class DetailViewController<T: ActivityProtocol>: BaseFlatFeedViewController
                                                             if let error = $0.error {
                                                                 self.showErrorAlert(error)
                                                             } else {
-                                                                self.reactionPaginator?.load(.limit(100), completion: self.commentsLoaded)
+                                                                self.resetComments()
                                                             }
                                                         }
         }

--- a/Sources/Components/Flat Feed/FlatFeedPresenter.swift
+++ b/Sources/Components/Flat Feed/FlatFeedPresenter.swift
@@ -38,6 +38,11 @@ public final class FlatFeedPresenter<T: ActivityProtocol>: PaginatorProtocol {
         subscriptionPresenter = SubscriptionPresenter(feed: flatFeed)
     }
     
+    /// Resets the items loaded so far.
+    public func reset() {
+        items = []
+    }
+    
     /// Load feed with a pagination. See `Pagination`.
     public func load(_ pagination: Pagination = .none, completion: @escaping Completion) {
         flatFeed.get(typeOf: T.self, pagination: pagination, includeReactions: includeReactions) { [weak self] result in

--- a/Sources/Components/Notifications/NotificationsPresenter.swift
+++ b/Sources/Components/Notifications/NotificationsPresenter.swift
@@ -38,6 +38,11 @@ public final class NotificationsPresenter<T: ActivityProtocol>: PaginatorProtoco
 }
 
 extension NotificationsPresenter {
+    /// Resets the notifications loaded so far.
+    public func reset() {
+        items = []
+    }
+    
     /// Load notifications with a given pagination options.
     public func load(_ pagination: Pagination = .none, completion: @escaping Completion) {
         notificationFeed.get(typeOf: T.self, pagination: pagination, markOption: markOption) { [weak self] result in

--- a/Sources/Components/Reaction/ReactionPaginator.swift
+++ b/Sources/Components/Reaction/ReactionPaginator.swift
@@ -30,9 +30,14 @@ public final class ReactionPaginator<T: ReactionExtraDataProtocol, U: UserProtoc
     }
 }
 
-// MARK: - Pagiantion
+// MARK: - Pagination
 
 extension ReactionPaginator {
+    /// Resets the reactions loaded so far.
+    public func reset() {
+        items = []
+    }
+    
     /// Load reactions with a given pagination options.
     public func load(_ pagination: Pagination = .none, completion: @escaping Completion) {
         Client.shared.reactions(forActivityId: activityId,

--- a/Sources/Models/Protocols/PaginatorProtocol.swift
+++ b/Sources/Models/Protocols/PaginatorProtocol.swift
@@ -17,6 +17,8 @@ public protocol PaginatorProtocol {
     var hasNext: Bool { get }
     var count: Int { get }
     
+    func reset()
+    
     func load(_ pagination: Pagination, completion: @escaping Completion)
     
     func loadNext(completion: @escaping Completion)


### PR DESCRIPTION
This bug can be easily replicated by running the sample and refreshing an activity with comments